### PR TITLE
Ability to customize Upstart, SystemD and SysVInit service configuration...

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ of variables that **must** differ in each role invocation:
 * ``tomcat_service_name``: Configure name for Tomcat service (string, default: ``{{ tomcat_user_name }}``)
 * ``tomcat_service_umask``: Configure umask (just the 4 digit value) for Tomcat service (string, default: None)
 * ``tomcat_server_xml_template``: Configure path to template for Tomcat configuration file _server.xml_ (string, default: ``server.xml.j2``)
+* ``tomcat_server_systemd_template``: Configure path to template for Tomcat SystemD config _tomcat.service_ (string, default: ``service_systemd.j2``)
+* ``tomcat_server_sysvinit_template``: Configure path to template for Tomcat sysvinit config _tomcat_ (string, default: ``service_sysvinit.j2``)
+* ``tomcat_server_upstart_template``: Configure path to template for Tomcat Upstart config _tomcat.conf_ (string, default: ``service_upstart.j2``)
+
 
 Tomcat instances must get configured with different ports in your inventory/playbook.
 Defaults for these ports are not accessable as variables but are used with jinja |default()

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,9 @@ tomcat_env_catalina_base: "{{ tomcat_user_home }}/catalina"
 tomcat_service_name: "{{ tomcat_user_name }}"
 #   template for configuration file server.xml
 tomcat_server_xml_template: server.xml.j2
+#   template for upstart
+tomcat_server_upstart_template: service_upstart.j2
+#   template for sysvinit
+tomcat_server_sysvinit_template: service_sysvinit.j2
+#   template for systemd
+tomcat_server_systemd_template: service_systemd.j2

--- a/tasks/service_systemd.yml
+++ b/tasks/service_systemd.yml
@@ -12,7 +12,7 @@
   tags: tomcat
   notify: service restart {{ tomcat_service_name }}
   template:
-    src=service_systemd.j2
+    src={{ tomcat_server_systemd_template }}
     dest=/etc/systemd/system/{{ tomcat_service_name }}.service
     owner=0
     group=0

--- a/tasks/service_sysvinit.yml
+++ b/tasks/service_sysvinit.yml
@@ -3,7 +3,7 @@
   tags: tomcat
   notify: service restart {{ tomcat_service_name }}
   template:
-    src=service_sysvinit.j2
+    src=tomcat_server_sysvinit_template
     dest=/etc/init.d/{{ tomcat_service_name }}
     owner=0
     group=0

--- a/tasks/service_upstart.yml
+++ b/tasks/service_upstart.yml
@@ -3,7 +3,7 @@
   tags: tomcat
   notify: service restart {{ tomcat_service_name }}
   template:
-    src=service_upstart.j2
+    src={{ tomcat_server_upstart_template }}
     dest=/etc/init/{{ tomcat_service_name }}.conf
     owner=0
     group=0


### PR DESCRIPTION
... by providing alternate templates

This change provides greater flexibility to playbooks that consume the role by allowing the consumer to specify their own templates for service configuration.

However, templates default to those within the role so as not to burden every role user with the need to build their own template.