### PR TITLE
Fix service stop on EL6

### DIFF
--- a/templates/service_sysvinit.j2
+++ b/templates/service_sysvinit.j2
@@ -14,7 +14,7 @@ export PATH=${PATH}:${JAVA_HOME}/bin
 export CATALINA_HOME={{ tomcat_env_catalina_home }}
 export CATALINA_BASE={{ tomcat_env_catalina_base }}
 export CATALINA_OPTS="{{ tomcat_env_catalina_opts|default('') }}"
-
+export CATALINA_PID=/var/run/tomcat.pid
 
 : ${ret:=0}
 LOCK=/var/run/tomcat.lock


### PR DESCRIPTION
sysvinit template (https://github.com/silpion/ansible-tomcat/blob/master/templates/service_sysvinit.j2) did not define any PID file.

EL6 killproc rely on PID file.

Simply add PID file on `/var/run/tomcat.pid`