### PR TITLE
Introduced a new variable to configure instance path to be different …

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Be sure to install required roles with
 * ``tomcat_default_port_redirect``: Default redirect port when not configured per instance (int, default: ``8443``)
 * ``tomcat_default_port_shutdown``: Default shutdown port when not configured per instance (int, default: ``8005``)
 * ``tomcat_default_catalina_opts``: Default configuration for environment variable "CATALINA_OPTS" when not configured per instance (string, default: ``''``)
+* ``tomcat_default_instance_path``: Default configuration for base path per instance (string, default: ``/srv/{{ tomcat_default_user_name }}``)
 * ``tomcat_server_systemd_template``: Default template to use when configuring Tomcat for Systemd (string, default: ``service_systemd.j2`` (see ``vars/service/systemd.yml``))
 * ``tomcat_server_sysvinit_template``: Default template to use when configuring Tomcat for SysV (string, default: ``service_sysvinit.j2`` (see ``vars/service/sysvinit.yml``))
 * ``tomcat_server_upstart_template``: Default template to use when configuring Tomcat for upstart (string, default: ``service_upstart.j2`` (see ``vars/service/upstart.yml``))
@@ -73,6 +74,7 @@ instance. The following variables are legit to configure per instance.
 * ``group``: Group for the user to run Tomcat instance as (string, default: ``{{ tomcat_default_user_group }}``)
 * ``user``: User to run Tomcat instance as (string, default: ``{{ tomcat_default_user_name }}``)
 * ``home``: Home directory for the user to run Tomcat instance as (string, default: ``{{ tomcat_default_user_home }}``)
+* ``path``: Directory of the tomcat instance as (string, default: ``{{ tomcat_default_instance_path }}``)
 * ``service_template``: Configure service template to use for a specific instance (string, default: ``{{ tomcat_default_service_template }}`` (see ``vars/service/*.yml``))
 * ``server_xml_template``: server.xml template to use for configuring Tomcat instance (string, default: ``{{ tomcat_default_server_xml_template }}``)
 * ``port_ajp``: Instance AJP port (int, default: ``{{ tomcat_default_port_ajp }}``)
@@ -231,7 +233,7 @@ enabled system, e.g. RHEL6.
 * ``item.service_name``
 * ``item.service_file``
 * ``item.user``
-* ``item.home``
+* ``item.path``
 
 **NOTE**: ``item.service_name`` and ``item.service_file`` names must match.
 
@@ -242,7 +244,8 @@ enabled system, e.g. RHEL6.
           - name: foo
             user: tomcatfoo
             group: tomcatfoo
-            home: /srv/tomcatfoo
+            path: /srv/tomcatfoo
+            home: /home/tomcatfoo
             service_name: tomcat-foo
             service_file: tomcat-foo
             port_ajp: 18009
@@ -252,7 +255,8 @@ enabled system, e.g. RHEL6.
           - name: bar
             user: tomcatbar
             group: tomcatbar
-            home: /srv/tomcatbar
+            path: /srv/tomcatbar
+            home: /home/tomcatbar
             service_name: tomcat-bar
             service_file: tomcat-bar
             port_ajp: 28009
@@ -274,7 +278,7 @@ The same playbook targeted on a Systemd enabled node.
 * ``item.service_name``
 * ``item.service_file``
 * ``item.user``
-* ``item.home``
+* ``item.path``
 
 <!-- -->
 
@@ -285,7 +289,8 @@ The same playbook targeted on a Systemd enabled node.
           - name: foo
             user: tomcatfoo
             group: tomcatfoo
-            home: /srv/tomcatfoo
+            path: /srv/tomcatfoo
+            home: /home/tomcatfoo
             service_name: foo@tomcat
             service_file: foo@.service
             port_ajp: 18009
@@ -295,7 +300,8 @@ The same playbook targeted on a Systemd enabled node.
           - name: bar
             user: tomcatbar
             group: tomcatbar
-            home: /srv/tomcatbar
+            path: /srv/tomcatbar
+            home: /home/tomcatbar
             service_name: bar@tomcat
             service_file: bar@.service
             port_ajp: 28009
@@ -317,7 +323,7 @@ The same playbook without sharing Systemd system slice.
 * ``item.service_name``
 * ``item.service_file``
 * ``item.user``
-* ``item.home``
+* ``item.path``
 
 <!-- -->
 
@@ -328,7 +334,8 @@ The same playbook without sharing Systemd system slice.
           - name: foo
             user: tomcatfoo
             group: tomcatfoo
-            home: /srv/tomcatfoo
+            path: /srv/tomcatfoo
+            home: /home/tomcatfoo
             service_name: tomcatfoo
             service_file: tomcatfoo.service
             port_ajp: 18009
@@ -338,7 +345,8 @@ The same playbook without sharing Systemd system slice.
           - name: bar
             user: tomcatbar
             group: tomcatbar
-            home: /srv/tomcatbar
+            path: /srv/tomcatbar
+            home: /home/tomcatbar
             service_name: tomcatbar
             service_file: tomcatbar.service
             port_ajp: 28009
@@ -365,6 +373,7 @@ all the defaults!
         tomcat_default_user_name: xyz
         tomcat_default_user_group: zyx
         tomcat_default_user_home: /var/home/xyz
+        tomcat_default_instance_path: /srv/xyz
         tomcat_default_server_xml_template: myveryownserverxmltemplate.j2
         tomcat_default_port_ajp: 12345
         tomcat_default_port_connector: 12346
@@ -401,6 +410,7 @@ override all the configuration but focus on instance configuration.
             user: xyz
             group: zyx
             home: /var/home/xyz
+            path: /srv/xyz
             service_template: myveryownsystemdtemplate.j2
             server_xml_template: myveryownserverxmltemplate.j2
             port_ajp: 12345

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,8 @@ tomcat_default_port_redirect: 8443
 tomcat_default_port_ajp: 8009
 #   Default CATALINA_OPTS (per instance name: item.catalina_opts)
 tomcat_default_catalina_opts: ''
-
+#   Default per instance path
+tomcat_default_instance_path: /srv/{{ tomcat_default_user_name }}
 
 # tomcat instance(s)
 tomcat_instances:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
     - tomcat_instance_dirs
   file:
     state=directory
-    dest={{ item.0.home|default(tomcat_default_user_home) }}/catalina/{{ item.0.name }}/{{ item.1 }}
+    dest={{ item.0.path|default(tomcat_default_instance_path) }}/catalina/{{ item.0.name }}/{{ item.1 }}
     owner={{ item.0.user|default(tomcat_default_user_name) }}
     group={{ item.0.group|default(tomcat_default_user_group) }}
     mode=0755
@@ -101,8 +101,8 @@
       --group {{ item.0.group|default(tomcat_default_user_group) }}
       --mode 0640
       {{ tomcat_env_catalina_home }}/conf/{{ item.1 }}
-      {{ item.0.home|default(tomcat_default_user_home) }}/catalina/{{ item.0.name }}/conf/{{ item.1 }}
-    creates={{ item.0.user|default(tomcat_default_user_home) }}/catalina/{{ item.0.name }}/conf/{{ item.1 }}
+      {{ item.0.path|default(tomcat_default_instance_path) }}/catalina/{{ item.0.name }}/conf/{{ item.1 }}
+    creates={{ item.0.path|default(tomcat_default_instance_path) }}/catalina/{{ item.0.name }}/conf/{{ item.1 }}
 
 
 - name: Install instance configurations
@@ -112,7 +112,7 @@
   register: tomcat_registered_install_instance_configurations
   template:
     src={{ item.server_xml_template|default(tomcat_default_server_xml_template) }}
-    dest={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/conf/server.xml
+    dest={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/conf/server.xml
     owner={{ item.user|default(tomcat_default_user_name) }}
     group={{ item.group|default(tomcat_default_user_group) }}
     mode=0640
@@ -132,7 +132,7 @@
   register: tomcat_registered_install_instance_environment_files
   template:
     src=service_systemd_envfile.j2
-    dest={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/.systemd.conf
+    dest={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/.systemd.conf
     owner={{ item.user|default(tomcat_default_user_name) }}
     group={{ item.group|default(tomcat_default_user_group) }}
     mode=0644

--- a/templates/service_systemd.j2
+++ b/templates/service_systemd.j2
@@ -14,51 +14,51 @@ Restart=on-failure
 Environment=TOMCAT_JAVA_HOME={{ ansible_local.java.general.java_home }}
 Environment=CATALINA_HOME={{ tomcat_env_catalina_home }}
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-EnvironmentFile=-{{ item.home|default(tomcat_default_user_home) }}/catalina/%i/.systemd.conf
+EnvironmentFile=-{{ item.path|default(tomcat_default_instance_path) }}/catalina/%i/.systemd.conf
 {% else %}
-EnvironmentFile=-{{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/.systemd.conf
+EnvironmentFile=-{{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/.systemd.conf
 {% endif %}
 
 ExecStart={{ ansible_local.java.general.java_home }}/bin/java \
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-  -Djava.util.logging.config.file={{ item.home|default(tomcat_default_user_home) }}/catalina/%i/conf/logging.properties \
+  -Djava.util.logging.config.file={{ item.path|default(tomcat_default_instance_path) }}/catalina/%i/conf/logging.properties \
 {% else %}
-  -Djava.util.logging.config.file={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/conf/logging.properties \
+  -Djava.util.logging.config.file={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/conf/logging.properties \
 {% endif %}
   -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager \
   -Djava.endorsed.dirs={{ tomcat_env_catalina_home }}/endorsed \
   -Dcatalina.home={{ tomcat_env_catalina_home }} \
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-  -Dcatalina.base={{ item.home|default(tomcat_default_user_home) }}/catalina/%i \
+  -Dcatalina.base={{ item.path|default(tomcat_default_instance_path) }}/catalina/%i \
 {% else %}
-  -Dcatalina.base={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }} \
+  -Dcatalina.base={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }} \
 {% endif %}
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-  -Djava.io.tmpdir={{ item.home|default(tomcat_default_user_home) }}/%i/temp \
+  -Djava.io.tmpdir={{ item.path|default(tomcat_default_instance_path) }}/catalina/%i/temp \
 {% else %}
-  -Djava.io.tmpdir={{ item.home|default(tomcat_default_user_home) }}/{{ item.name }}/temp \
+  -Djava.io.tmpdir={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/temp \
 {% endif %}
   -classpath "{{ tomcat_env_catalina_home }}/bin/bootstrap.jar:{{ tomcat_env_catalina_home }}/bin/tomcat-juli.jar" \
   org.apache.catalina.startup.Bootstrap start
 
 ExecStop={{ ansible_local.java.general.java_home }}/bin/java \
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-  -Djava.util.logging.config.file={{ item.home|default(tomcat_default_user_home) }}/catalina/%i/conf/logging.properties \
+  -Djava.util.logging.config.file={{ item.path|default(tomcat_default_instance_path) }}/catalina/%i/conf/logging.properties \
 {% else %}
-  -Djava.util.logging.config.file={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/conf/logging.properties \
+  -Djava.util.logging.config.file={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/conf/logging.properties \
 {% endif %}
   -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager \
   -Djava.endorsed.dirs={{ tomcat_env_catalina_home }}/endorsed \
   -Dcatalina.home={{ tomcat_env_catalina_home }} \
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-  -Dcatalina.base={{ item.home|default(tomcat_default_user_home) }}/catalina/%i \
+  -Dcatalina.base={{ item.path|default(tomcat_default_instance_path) }}/catalina/%i \
 {% else %}
-  -Dcatalina.base={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }} \
+  -Dcatalina.base={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }} \
 {% endif %}
 {% if item.service_name|default(tomcat_default_service_name)|search('@') %}
-  -Djava.io.tmpdir={{ item.home|default(tomcat_default_user_home) }}/%i/temp \
+  -Djava.io.tmpdir={{ item.path|default(tomcat_default_instance_path) }}/catalina/%i/temp \
 {% else %}
-  -Djava.io.tmpdir={{ item.home|default(tomcat_default_user_home) }}/{{ item.name }}/temp \
+  -Djava.io.tmpdir={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/temp \
 {% endif %}
   -classpath "{{ tomcat_env_catalina_home }}/bin/bootstrap.jar:{{ tomcat_env_catalina_home }}/bin/tomcat-juli.jar" \
   org.apache.catalina.startup.Bootstrap stop

--- a/templates/service_systemd_envfile.j2
+++ b/templates/service_systemd_envfile.j2
@@ -1,2 +1,2 @@
-CATALINA_BASE={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}
+CATALINA_BASE={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}
 CATALINA_OPTS={{ item.catalina_opts|default(tomcat_default_catalina_opts) }}

--- a/templates/service_sysvinit.j2
+++ b/templates/service_sysvinit.j2
@@ -12,8 +12,8 @@ export TOMCAT_USER={{ item.user|default(tomcat_default_user_name) }}
 export JAVA_HOME={{ ansible_local.java.general.java_home }}
 export PATH=${PATH}:${JAVA_HOME}/bin
 export CATALINA_HOME={{ tomcat_env_catalina_home }}
-export CATALINA_BASE={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}
-export CATALINA_PID={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/{{ item.name }}.pid
+export CATALINA_BASE={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}
+export CATALINA_PID={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/{{ item.name }}.pid
 export CATALINA_OPTS="{{ item.catalina_opts|default(tomcat_default_catalina_opts) }}"
 
 
@@ -35,7 +35,7 @@ start(){
 
 stop(){
   echo -n $"Stopping $PROC: "
-  killproc -p {{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/{{ item.name }}.pid $PROC
+  killproc -p {{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/{{ item.name }}.pid $PROC
   ret=$?
   echo
   [ $ret -eq 0 ] && rm -f $LOCK
@@ -54,7 +54,7 @@ case "$1" in
     start
   ;;
   status)
-    status -p {{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/{{ item.name }}.pid $PROC
+    status -p {{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/{{ item.name }}.pid $PROC
   ;;
   *)
     echo $"Usage: $PROC {start|stop|restart|status}"

--- a/templates/service_upstart.j2
+++ b/templates/service_upstart.j2
@@ -10,7 +10,7 @@ setgid {{ item.group|default(tomcat_default_user_group) }}
 
 env JAVA_HOME={{ ansible_local.java.general.java_home }}
 env CATALINA_HOME={{ tomcat_env_catalina_home }}
-env CATALINA_BASE={{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}
+env CATALINA_BASE={{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}
 env CATALINA_OPTS="{{ item.catalina_opts|default(tomcat_default_catalina_opts) }}"
 
 script
@@ -21,5 +21,5 @@ script
 end script
 
 post-stop script
-  rm -rf {{ item.home|default(tomcat_default_user_home) }}/catalina/{{ item.name }}/temp/*
+  rm -rf {{ item.path|default(tomcat_default_instance_path) }}/catalina/{{ item.name }}/temp/*
 end script


### PR DESCRIPTION
…from the user home + fixed temp dir path issue within service_systemd.j2

Details:
- the existing implementation constraints the user home directory to be the tomcat instance's path. The existing implementation breaks if one tries to configure tomcat to run as an user already existing within the system.

- the temp directory path within service_systemd.j2 seems wrong (the catalina folder is missing)