### PR TITLE
catalina_base facts and facts overriding mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Be sure to install required roles with
 * ``tomcat_server_sysvinit_template``: Default template to use when configuring Tomcat for SysV (string, default: ``service_sysvinit.j2`` (see ``vars/service/sysvinit.yml``))
 * ``tomcat_server_upstart_template``: Default template to use when configuring Tomcat for upstart (string, default: ``service_upstart.j2`` (see ``vars/service/upstart.yml``))
 * ``tomcat_service_allow_restart``: Whether to allow or deny restarting Tomcat instances automatically (boolean, default: ``true``)
+* ``tomcat_facts_template``: Default template to use when configuring Tomcat facts.d (string, default: ``facts.j2``)
 
 ### tomcat_instances
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,9 @@ tomcat_instances:
   - name: tomcat
 
 
+#   template for ansible tomcat facts
+tomcat_facts_template: facts.j2
+
 #   template for upstart
 tomcat_server_upstart_template: service_upstart.j2
 #   template for sysvinit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -212,7 +212,7 @@
   become: yes
   register: tomcat_registered_install_local_tomcat_facts
   template:
-    src=facts.j2
+    src={{ tomcat_facts_template }}
     dest=/etc/ansible/facts.d/tomcat.fact
     owner=0
     group=0

--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -1,25 +1,27 @@
-{% if util_template_use_cow %}
-#  --------------------
-# ( Managed by Ansible )
-#  --------------------
-#   o            .    .     .
-#    o      .  . .     `  ,
-#     o    .; .  : .' :  :  : .
-#      o   i..`: i` i.i.,i  i .
-#       o   `,--.|i |i|ii|ii|i:
-#            UooU\.'@@@@@@`.||'
-#            \__/(@@@@@@@@@@)'
-#                 (@@@@@@@@)
-#                 `YY~~~~YY'
-#                  ||    ||
-{% else %}
-# {{ ansible_managed }}
-{% endif %}
-
-[general]
-version = {{ tomcat_version }}
-
+{
+    "general": {
+        "version": "{{ tomcat_version }}",
+        "catalina_home": "{{ tomcat_env_catalina_home }}",
+        "allow_restart": {{ tomcat_service_allow_restart|lower }}
+    },  
+    "instances": {
 {% for instance in tomcat_instances %}
-[instances/{{ instance.name }}]
-catalina_base = {{ instance.path|default(tomcat_default_instance_path) }}/catalina/{{ instance.name }}
+        "{{ instance.name }}": {
+            "catalina_base": "{{ instance.path|default(tomcat_default_instance_path) }}/catalina/{{ instance.name }}",
+            "port": {
+                "shutdown": {{ instance.port_shutdown|default(tomcat_default_port_shutdown) }},
+                "connector": {{ instance.port_connector|default(tomcat_default_port_connector) }},
+                "redirect": {{ instance.port_redirect|default(tomcat_default_port_redirect) }},
+                "ajp": {{ instance.port_ajp|default(tomcat_default_port_ajp) }}
+            },
+            "user": "{{ instance.user|default(tomcat_default_user_name) }}",
+            "group": "{{ instance.group|default(tomcat_default_user_group) }}",
+            "service": {
+                "name": "{{ instance.service_name|default(tomcat_default_service_name) }}",
+                "file": "{{ tomcat_service_dir }}/{{ instance.service_file|default(tomcat_default_service_file) }}"
+            }
+        }{% if not loop.last %},{% endif %}
+
 {% endfor %}
+    }
+}

--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -18,3 +18,8 @@
 
 [general]
 version = {{ tomcat_version }}
+
+{% for instance in tomcat_instances %}
+[instances/{{ instance.name }}]
+catalina_base = {{ instance.path|default(tomcat_default_instance_path) }}/catalina/{{ instance.name }}
+{% endfor %}


### PR DESCRIPTION
As discussed on #13 

Moreover I need review for the second part `catalina_base` facts.

I add `catalina_base` on facts but two questions:

1. Should be add by default? Or keep only `version`
2. By using `ini` format we can't create nested section `instance -> {{ instance.name }}`, so two solutions:
    1. Use convention like `[instance:foo]`, `[instance_foo]`, `[instance/foo]`
    2. Use json 

```
{
    "general": {"version":"{{ tomcat_version }}"},  
    "instances": {
{% for instance in tomcat_instances %}  
        "{{ instance.name }}":{"catalina_base":"{{ instance.path|default(tomcat_default_instance_path) }}/catalina/{{ instance.name }}"}{% if not loop.last %},{% endif %}
{% endfor %}
    }
}
```

that will produce something like

```json
127.0.0.1 | success >> {
    "ansible_facts": {
        "ansible_local": {
            "java": {
                "general": {
                    "java_home": "/usr/java/default"
                }
            }, 
            "tomcat": {
                "general": {
                    "version": "7.0.62"
                }, 
                "instances": {
                    "foo": {
                        "catalina_base": "/home/vagrant/catalina/foo"
                    }
                }
            }, 
            "util": {
                "init": {
                    "system": "sysvinit"
                }
            }
        }
    }, 
    "changed": false
}
```

but `json` does not allow comment, so we will loose the fabulous cow

```
#  --------------------
# ( Managed by Ansible )
#  --------------------
#   o            .    .     .
#    o      .  . .     `  ,
#     o    .; .  : .' :  :  : .
#      o   i..`: i` i.i.,i  i .
#       o   `,--.|i |i|ii|ii|i:
#            UooU\.'@@@@@@`.||'
#            \__/(@@@@@@@@@@)'
#                 (@@@@@@@@)
#                 `YY~~~~YY'
#                  ||    ||
```