### PR TITLE
add missing catalina_base directories: bin, lib and work

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -21,6 +21,9 @@ tomcat_instance_dirs:
   - logs
   - webapps
   - temp
+  - bin
+  - lib
+  - work
 
 # installation directory, denoted by environment variable CATALINA_HOME
 tomcat_env_catalina_home: "{{ tomcat_install_base }}/apache-tomcat-{{ tomcat_version }}"


### PR DESCRIPTION
Reference #14 

According to Tomcat documentation http://tomcat.apache.org/tomcat-8.0-doc/RUNNING.txt section *Advanced Configuration - Multiple Tomcat Instances*

```
When running with a separate CATALINA_HOME and CATALINA_BASE, the files
and directories are split as following:

In CATALINA_BASE:

 * bin  - Only the following files:
           * setenv.sh (*nix) or setenv.bat (Windows),
           * tomcat-juli.jar
          The setenv scripts were described above. The tomcat-juli library
          is documented in the Logging chapter in the User Guide.
 * conf - Server configuration files (including server.xml)
 * lib  - Libraries and classes, as explained below
 * logs - Log and output files
 * webapps - Automatically loaded web applications
 * work - Temporary working directories for web applications
 * temp - Directory used by the JVM for temporary files (java.io.tmpdir)
```

In my personal case I really need to add `setenv.sh` and jarfile on `lib` folder. Actually I need to create both folders before importing those files.
