### PR TITLE
[Simone] Fix status not working in service_sysvinit.j2

### DIFF
--- a/templates/service_sysvinit.j2
+++ b/templates/service_sysvinit.j2
@@ -62,7 +62,7 @@ case "$1" in
     start
   ;;
   status)
-    status -p $CATALINA_GROUP $PROC
+    status -p $CATALINA_PID $PROC
   ;;
   *)
     echo $"Usage: $PROC {start|stop|restart|status}"


### PR DESCRIPTION
SysvInit script isn't able to check status of process because there's a wrong variable usage

